### PR TITLE
add delay

### DIFF
--- a/web3-functions/rfx-pyth-automation/config.ts
+++ b/web3-functions/rfx-pyth-automation/config.ts
@@ -177,5 +177,3 @@ export const feedIdCache: Record<string, string> = {
 export const baseFeedIdCache: Record<string, string> = {
   "0x2dEd5585e0bE28bb0735D01c403F064a8986d2B9" : "0xc9d8b075a5c69303365ae23633d4e085199bf5c520a3b90fed1322a0342ffc33", // ETH/BTC
 }
-
-

--- a/web3-functions/rfx-pyth-automation/index.ts
+++ b/web3-functions/rfx-pyth-automation/index.ts
@@ -11,15 +11,14 @@ import WithdrawalHandlerAbi from './abis/WithdrawalHandler.json';
 
 import PythAbi from "@pythnetwork/pyth-sdk-solidity/abis/IPyth.json";
 
-import { decodeEventData, getOracleParams } from "./utils"
+import { decodeEventData, getOracleParams, sleep } from "./utils"
 import { MarketProps, marketProps, config } from "./config"
-import { Contract, ethers } from "ethers";
+import { Contract } from "ethers";
 
 Web3Function.onRun(async (context: Web3FunctionEventContext) => {
   const { log, secrets, multiChainProvider } = context;
 
   const HERMES_ENDPOINT = await secrets.get("HERMES_ENDPOINT");
-  // const KEEPER_PRIVATE_KEY = await secrets.get("KEEPER_PRIVATE_KEY");
 
   try {
     // Parse the event from the log using the provided event ABI
@@ -58,6 +57,9 @@ Web3Function.onRun(async (context: Web3FunctionEventContext) => {
 
     console.log(`order tx: ${log.transactionHash}`);
 
+    // sleep 2 seconds to reduce chances of w3f passing simulation when other automation executes the item
+    await sleep(2 * 1000);
+
     let props: MarketProps[] = [];
     props.push(marketProps[market])
 
@@ -71,8 +73,7 @@ Web3Function.onRun(async (context: Web3FunctionEventContext) => {
       props.push(marketProps[swapPath[i]]);
     }
 
-    const provider = multiChainProvider.default();//new ethers.providers.JsonRpcProvider(config.RPC);
-    // const signer = new ethers.Wallet(KEEPER_PRIVATE_KEY!, provider);
+    const provider = multiChainProvider.default();
     
     const pythContract = new Contract(
       config.PythOracle,
@@ -82,8 +83,6 @@ Web3Function.onRun(async (context: Web3FunctionEventContext) => {
 
     const blockTimestamp = (await provider.getBlock(log.blockNumber)).timestamp;
     const { oracleParams, updateFee } = await getOracleParams(props, blockTimestamp, pythContract, HERMES_ENDPOINT!);
-
-    let res;
 
     if (event.args[1] == "DepositCreated") {
       const depositHandler = new Contract(
@@ -95,11 +94,6 @@ Web3Function.onRun(async (context: Web3FunctionEventContext) => {
         canExec: true,
         callData: [{to: depositHandler.address, data: depositHandler.interface.encodeFunctionData("executeDeposit", [key, oracleParams]), value: updateFee.toString()}]
       }
-      /*
-      res = await depositHandler.executeDeposit(key, oracleParams, {
-        value: updateFee, gasLimit: 10000000
-      });
-      */
     }
     
     else if (event.args[1] == "OrderCreated") {
@@ -112,12 +106,6 @@ Web3Function.onRun(async (context: Web3FunctionEventContext) => {
         canExec: true,
         callData: [{to: orderHandler.address, data: orderHandler.interface.encodeFunctionData("executeOrder", [key, oracleParams]), value: updateFee.toString()}]
       }
-
-      /*
-      res = await orderHandler.executeOrder(key, oracleParams, {
-        value: updateFee, gasLimit: 10000000
-      });
-      */
     }
     
     else if (event.args[1] == "WithdrawalCreated") {
@@ -130,21 +118,7 @@ Web3Function.onRun(async (context: Web3FunctionEventContext) => {
         canExec: true,
         callData: [{to: withdrawalHandler.address, data: withdrawalHandler.interface.encodeFunctionData("executeWithdrawal", [key, oracleParams]), value: updateFee.toString()}]
       }
-
-      /*
-      // executeOrder???
-      res = await withdrawalHandler.executeOrder(key, oracleParams, {
-        value: updateFee, gasLimit: 10000000
-      });
-      */
     }
-
-    /*
-    console.log(`sent tx: ${res.hash}`)
-    await res.wait();
-    
-    console.log(`tx successful`)
-    */
 
     return {
       canExec: false,

--- a/web3-functions/rfx-pyth-automation/utils.ts
+++ b/web3-functions/rfx-pyth-automation/utils.ts
@@ -11,6 +11,8 @@ export interface OracleParams {
     data: string[];
 }
 
+export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
 export function decodeEventData(originalObject: any[][][][]): {
     key: string;
     market: string;


### PR DESCRIPTION
Adding delay makes sure the servers that we run execute the orders at a lower gas fee. Any events missed by our primary servers will be covered by this Gelato web3f for a higher execution fee